### PR TITLE
Fix compatibility 7.16

### DIFF
--- a/src/ListviewSearchUI/widget/ListviewSearchUI.js
+++ b/src/ListviewSearchUI/widget/ListviewSearchUI.js
@@ -100,16 +100,7 @@ define([
 
             // set the listener for page navigation due to OPR page reloading could mean
             // the new widget is already present before the old one is removed
-            var currentForm = null;
-            if (mx.router && mx.router.getContentForm) {
-                currentForm = mx.router.getContentForm();
-            } else if (mx.ui.getCurrentForm) {
-                currentForm = mx.ui.getCurrentForm();
-            }
-
-            if (currentForm) {
-                this._navigationListener = dojo.connect(currentForm, "onNavigation", dojoLang.hitch(this,this._onPageNavigation));
-            }
+            this._navigationListener = dojo.connect(this.mxform, "onNavigation", dojoLang.hitch(this,this._onPageNavigation));
         },
 
         // mxui.widget._WidgetBase.update is called when context is changed or initialized. Implement to re-render and / or fetch data.


### PR DESCRIPTION
`getContentForm` does not seems to be available any longer. 
widgetBase has prop `this.mxform` which is save to use. https://apidocs.mendix.com/7/client/mxui_lib_form__FormBase.html